### PR TITLE
Add support for Symfony 3 & 4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,17 @@
 language: php
+dist: bionic
 
 php:
-  - 5.6
-  - 5.5
-  - 5.4
-  - hhvm
-  - hhvm-nightly
+  - 7.1
+  - 7.2
+  - 7.3
 
 install:
     - composer install --prefer-source
 
-script: vendor/bin/peridot specs/
+script:
+    - vendor/bin/peridot specs/
+    - vendor/bin/peridot app/specs/
 
 matrix:
   fast_finish: true
-  allow_failures:
-    - php: hhvm-nightly

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         }
     ],
     "require": {
-        "symfony/browser-kit": "~2.0",
+        "symfony/browser-kit": "~2.0|~3.0|~4.0",
         "peridot-php/peridot": "~1.0"
     },
     "autoload": {
@@ -18,6 +18,6 @@
         }
     },
     "require-dev": {
-        "silex/silex": "~1.0"
+        "silex/silex": "~1.0|~2.0"
     }
 }


### PR DESCRIPTION
Add support for Symfony 3.x, 4.x, and test against Silex 2.x as well as 1.x. Also update the CI to use PHP versions that are not EOL